### PR TITLE
Add STD Library

### DIFF
--- a/std/stdarg.h
+++ b/std/stdarg.h
@@ -1,0 +1,41 @@
+#ifndef mclib_stdarg_h__17_12_07____16_47_53
+#define mclib_stdarg_h__17_12_07____16_47_53
+#include <mclib.h>
+
+#include <stdlib.h>
+
+/**
+ * FIXME: Requires co-operation with the compiler to implement.
+ * TODO: Implement Variadic Function Complete Implementation.
+ */
+
+typedef char* va_list;
+
+void va_start_impl(va_list* list,void* from)
+{
+*list = from;
+}
+
+
+
+void* va_arg_impl(va_list* list,int size){
+	void* t = *list;
+	*list +=size;
+	return t;
+}
+
+void va_end_impl(va_list* list){
+	free(list);
+  free(*list);
+}
+
+
+
+
+#define va_start(list,from) va_start_impl(&list,(&from)+1)
+
+#define va_arg(list,type) *(type*)(va_arg_impl(&list,sizeof(type)))
+
+#define va_end(list) va_end_impl(&list)
+
+#endif

--- a/std/stdbool.h
+++ b/std/stdbool.h
@@ -1,0 +1,11 @@
+#ifndef mclib_stdbool_h__17_12_08____09_01_29
+#define mclib_stdbool_h__17_12_08____09_01_29
+#include <mclib.h>
+#include <stddef.h>
+
+#define bool int
+#define true 1
+#define false 0
+
+
+#endif

--- a/std/stddef.h
+++ b/std/stddef.h
@@ -1,0 +1,7 @@
+#ifndef mclib_stddef_h__17_12_11____09_13_47
+#define mclib_stddef_h__17_12_11____09_13_47
+#include <mclib.h>
+
+#define NULL 0
+
+#endif


### PR DESCRIPTION
Adds 3 parts of the standard library. Compiler should change to use the folder std, on the inclusion path, as well as reflect the requirements of stdarg.h (specifically, variadic functions should store parameters in a specialzied table, to allow for va_start_impl to work correctly). If anything is not possible, or needs further explaination, please comment.